### PR TITLE
Adding ssl option on simpleOptions keys to be considered

### DIFF
--- a/lib/bin/pgen.js
+++ b/lib/bin/pgen.js
@@ -152,7 +152,7 @@ function execScenario(options) {
  */
 function simpleOptions(options) {
     let simpleOptions = {};
-    let keys = ['host', 'port', 'user', 'password', 'database', 'schema', 'templateDir', 'target', 'log', 'extension', 'indent', 'datafile', 'optionsfile', 'nobeautifier'];
+    let keys = ['host', 'port', 'user', 'password', 'database', 'schema', 'templateDir', 'target', 'log', 'extension', 'indent', 'datafile', 'optionsfile', 'nobeautifier', 'ssl'];
 
     for (let key of keys) {
         simpleOptions[key] = options[key];


### PR DESCRIPTION
SSL option was not considered on execScenario, after the line  of code 120, options variable didn't have  the SSL.