### PR TITLE
feat: add config cli option

### DIFF
--- a/lib/bin/pgen.js
+++ b/lib/bin/pgen.js
@@ -61,6 +61,8 @@ program
   .option('-d, --database [database]',    'Database name')
   .option('-u, --user [user]',            'Username to connect to database')
   .option('-p, --password [password]',    'Password to connect to database')
+  .option('-c, --config [file]',          'Path to sequelize config file (json/js) for database connection values. See https://github.com/sequelize/cli#configuration-file')
+  .option('-e, --env [env]',              `If --config is supplied, this configuration for this environment will be used. Default: ${theme.default('development')}`, 'development')
   .option('-s, --schema [schemas]',       `Comma separated names of the database schemas. i.e public,extra_schema. Default: ${theme.default('public')}`, 'public')
   .option('    --ssl',                    'Adds ssl=true option to conection.')
   .option('    --log [level]',            `Log detail level. error|warn|info|verbose|debug. Default: ${theme.default('info')}`, 'info')
@@ -119,7 +121,17 @@ function templateScenario() {
 
 function execScenario(options) {
   const ask = !!options;
+
   options = options ? convertToSimpleOptions(options) || {} : {};
+
+  if (options.config) {
+      const configFile = path.resolve(options.config);
+      const allConfigs = require(configFile);
+      const config = allConfigs[options.env] || {};
+      // add config values to options, but assign existing options last so explicitly
+      // defined options take precedence.
+      options = lodash.defaultsDeep({ user: config.username }, config, options);
+  }
 
   inquirer.prompt([
         { name: 'host', message: 'Host', default: 'localhost', when: () => !ask },
@@ -155,7 +167,7 @@ function execScenario(options) {
  */
 function convertToSimpleOptions(options) {
   const simpleOptions = {};
-  const keys = ['host', 'port', 'user', 'password', 'database', 'schema', 'templateDir', 'target', 'log', 'extension', 'indent', 'datafile', 'optionsfile', 'nobeautifier', 'fix', 'ssl'];
+  const keys = ['host', 'port', 'user', 'password', 'database', 'schema', 'templateDir', 'target', 'log', 'extension', 'indent', 'datafile', 'optionsfile', 'nobeautifier', 'fix', 'ssl', 'config', 'env'];
 
   for (const key of keys) {
     simpleOptions[key] = options[key];

--- a/test/05-cli-config.js
+++ b/test/05-cli-config.js
@@ -1,0 +1,74 @@
+'use strict';
+const Lab             = require('lab');
+const Chai            = require('chai');
+const Generator       = require('../index.js');
+const path            = require('path');
+const fs              = require('fs-extra');
+
+const lab         = exports.lab = Lab.script();
+const describe    = lab.describe;
+const it          = lab.it;
+const testDB      = require('./util/test-db.js');
+const expect      = Chai.expect;
+
+const Sequelize   = require('sequelize');
+const sequelize   = new Sequelize(testDB.credentials.database, testDB.credentials.user,  testDB.credentials.password, { dialect: 'postgres', logging: false });
+
+const exec        = require('mz/child_process').exec;
+
+let model;
+
+const targetDir = path.join(__dirname, 'model-sequelize-2');
+
+lab.before((done) => {
+    testDB.createDB(1)
+        .then(() => {
+            let cmd = `node ${path.join(__dirname, '../lib/bin/pgen.js')} exec template/sequelize `;
+            cmd    += `--config ${path.join(__dirname, 'util/test-config.json')} `;
+            cmd    += `--target ${targetDir} --log error --fix `;
+            cmd    += `--datafile ${path.join(__dirname, 'util/custom-data.js')} `;
+            return exec(cmd);
+        })
+        .then(() => {
+            const modelFile = path.join(targetDir, 'index.js');
+            model = require(modelFile).init(sequelize);
+            done();
+        })
+        .catch(done);
+});
+
+lab.after((done) => {
+    testDB.dropDB().then(() => {
+        fs.removeSync(targetDir);
+        done();
+    });
+});
+
+describe('Cart model file', () => {
+    it ('should equal expected result.', (done) => {
+        const source      = fs.readFileSync(path.join(targetDir, 'definition/cart.js')).toString();
+        const expected    = fs.readFileSync(path.join(__dirname, 'util/expected/cart.js')).toString();
+        expect(source).to.equal(expected);
+        done();
+    });
+});
+
+describe('Cart model file', () => {
+    it ('should equal expected result.', (done) => {
+        const source      = fs.readFileSync(path.join(targetDir, '/definition/company.js')).toString();
+        const expected    = fs.readFileSync(path.join(__dirname, 'util/expected/company.js')).toString();
+        expect(source).to.equal(expected);
+        done();
+    });
+});
+
+describe('Company Instance', () => {
+    it ('should have a name', (done) => {
+        model.Company.findOne({ where: {id: 1} })
+            .then(function(company) {
+                expect(company.name).to.equal('Acmesai');
+                done();
+            })
+            .catch(done);
+    });
+});

--- a/test/util/test-config.json
+++ b/test/util/test-config.json
@@ -1,0 +1,9 @@
+{
+    "development": {
+        "database": "pg-generator-test-7348G63",
+        "username": "user",
+        "password": "password",
+        "host": "localhost",
+        "port": 5432
+    }
+}

--- a/test/util/test-db.js
+++ b/test/util/test-db.js
@@ -1,13 +1,14 @@
 const PgTestUtil  = require('pg-test-util');
 const path        = require('path');
+const config      = require('./test-config.json').development;
 
-const db = 'pg-generator-test-7348G63';
+const db = config.database;
 
 const dbOptions = {
-    host: 'localhost',
-    port: 5432,
-    user: 'user',
-    password: 'password',
+    host: config.host,
+    port: config.port,
+    user: config.user || config.username, // sequelize configs use 'username', not 'user'
+    password: config.password,
     defaultDatabase: db
 };
 


### PR DESCRIPTION
This adds `--config` and `--env` cli options, which work in the same way as in [sequelize-cli](https://github.com/sequelize/cli).

This allows users to re-use their sequelize `config.json`/`config.js` files, instead of having to pass in all database credentials from the command line.

So commands like this:
```cli
pgen exec template --host myhost --port 12345 --database mydb --user me --password password --target mytarget
```
will become something like
```cli
pgen exec template --config config.json --target mytarget
```
Where `config.json` is a [sequelize configuration file](https://github.com/sequelize/cli#configuration-file) (it could be either`.json` or `.js`).

This is preferable not just because it's shorter, but it avoids having to duplicate database credentials between the sequelize `config.json` and the command, making the cli tool more flexible. For example, it could be run from an npm script, without hard-coded db credentials or wrapping the command line in another shell script.

I added some tests for this, which verify using `--config` works the same as specifying options individually, but I wasn't able to run the tests even on master with no changes. I manually tested that my changes worked, but I can't seem from the repo how CI runs?