### PR TITLE
Added support of custom template filters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -184,6 +184,15 @@ class PGGenerator {
     this.templateModule     = this.requireModule();
 
     addFilters(this.nunjucksEnv);
+
+    fs.access(this.templateDir + '/util/template-filter.js', fs.F_OK, err => {
+      if (!err) {
+        const templateAddFiltersModule = require(this.templateDir + '/util/template-filter');
+        if (templateAddFiltersModule && typeof templateAddFiltersModule.addFilters == 'function') {
+          templateAddFiltersModule.addFilters(this.nunjucksEnv);
+        }
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
There was an issue with using this project with generated models.

I have the following section in my custom-data.js file:
```javascript
Role: {
        hasMany: {
            FkUserRoleIdRoleRoleIdRoles: {
                as: 'users'
            }
        },
        belongsTo: {},
        getterMethods: {
            isApplicant: function () {
                return this.getDataValue('name') == 'applicant';
            },
            isAssistant: function () {
                return this.getDataValue('name') == 'assistant';
            },
            isCustomer: function () {
                return this.getDataValue('name') == 'customer';
            }
        }
    },
```
These getter methods weren't correctly exported to the resulting Role model because of unthoughtfully working 'stringifyIfObject' filter: it returned an empty object or a string in different variations of getter methods.

So I decided to add an ability to create own template filters inside of 'util/template-filter.js' file of the template folder (not the pg-generator folder!).
This pull request adds new nunjucks filters and makes them available for use with model generating template.

As for me, this new filter totally fixed the issue with getter methods:

```javascript
const addFilters = nunjucksEnvironment => {
    nunjucksEnvironment.addFilter('dumpWithMethods', function (obj, cpaces) {
        const getMethods = (obj) => {
            let result = [];
            for (let id in obj) {
                try {
                    if (typeof(obj[id]) == "function") {
                        result.push(id + ": " + obj[id].toString());
                    } else {
                        result.push(`${id}: ${JSON.stringify(obj[id], null, spaces)}`);
                    }
                } catch (err) {
                    result.push(id + ": inaccessible");
                }
            }
            return result;
        };

        return `{${getMethods(obj).join(',')}}`;
    });
};
```

So the following change in 'table/definition/{table.name # dashCase}.js.nunj.html' totally fixed the issue using the newly created filter:
```nunjucks
        {% for key, value in c -%} {# Custom table details from custom data not found in template #}
            {%- if (templateDataFields.indexOf(key) == -1) -%}
                ,{{ key }}: {{ value | dumpWithMethods }}
            {% endif -%}
        {% endfor -%}
```

How to use

Simply add a 'template-filter.js' file into the 'util' subdirectory of your template folder and write the code just as following:
```javascript
const addFilters = env => {
    env.addFilter('square', value => value * value);
};

module.exports.addFilters = addFilters;
```

And then you can use the new filter in your templates:

```nunjucks
{% set val = 4 %}
{{val | square}}
```